### PR TITLE
Allow arrow function parentheses.

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -5,6 +5,5 @@
   "singleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": true,
-  "arrowParens": "avoid",
   "proseWrap": "always"
 }


### PR DESCRIPTION
Зараз по стандарту Prettier рекомендується використовувати дужки для аргументів стрілочних функцій:
https://prettier.io/docs/en/options.html#arrow-function-parentheses