### PR TITLE
Upgrade UI/UX for adding water entries.

### DIFF
--- a/src/components/DailyInfo/DailyInfo.jsx
+++ b/src/components/DailyInfo/DailyInfo.jsx
@@ -3,11 +3,13 @@ import ChooseDate from '../ChooseDate/ChooseDate';
 import WaterList from '../WaterList/WaterList';
 import WaterModal from '../WaterModal/WaterModal';
 import css from './DailyInfo.module.css';
-import { useState } from 'react';
 import { Modal } from '../Modal/Modal';
 import { useModal } from '../../hooks/useModalHook.js';
+import { selectFormattedCurrentDate } from '../../redux/date/selectors.js';
+import { useSelector } from 'react-redux';
 
 const DailyInfo = () => {
+  const date = useSelector(selectFormattedCurrentDate);
   const [isModalVisible, setModalVisible] = useModal();
 
   return (
@@ -21,7 +23,7 @@ const DailyInfo = () => {
 
       {isModalVisible && (
         <Modal toggleModal={setModalVisible}>
-          <WaterModal toggleModal={setModalVisible} />
+          <WaterModal toggleModal={setModalVisible} entry={{ date }} />
         </Modal>
       )}
     </div>

--- a/src/components/WaterForm/WaterForm.jsx
+++ b/src/components/WaterForm/WaterForm.jsx
@@ -36,8 +36,8 @@ const WaterForm = ({ entry, toggleModal }) => {
     return `${pad(date.getHours())}:${pad(date.getMinutes())}`;
   };
 
-  const [entryDate, setEntryDate] = useState(extractDate(entry.date));
-  const [entryTime, setEntryTime] = useState(extractTime(entry.date));
+  const entryDate = extractDate(entry.date);
+  const entryTime = extractTime(entry.date);
 
   const validationSchema = Yup.object().shape({
     time: Yup.string()

--- a/src/components/WaterForm/WaterForm.jsx
+++ b/src/components/WaterForm/WaterForm.jsx
@@ -14,7 +14,7 @@ import { selectIsLoading } from '../../redux/water/selectors';
 
 const WaterForm = ({ entry, toggleModal }) => {
   const dispatch = useDispatch();
-  // const isLoading = useSelector(selectIsLoading);
+  const isLoading = useSelector(selectIsLoading);
 
   const extractDate = (timestamp) => {
     if (timestamp) return timestamp.split(' ')[0];
@@ -111,7 +111,7 @@ const WaterForm = ({ entry, toggleModal }) => {
 
   return (
     <>
-      {/* {isLoading && <Loader />} */}
+      {isLoading && <Loader />}
       <form onSubmit={handleSubmit(onSubmit)} className={style.waterForm}>
         <p>{entry._id ? 'Correct entered data:' : 'Choose a value:'}</p>
         <div className={style.valuePickerContainer}>
@@ -179,11 +179,7 @@ const WaterForm = ({ entry, toggleModal }) => {
           )}
         </label>
         <br />
-        <button
-          className={style.saveBtn}
-          // disabled={isLoading}
-          type="submit"
-        >
+        <button className={style.saveBtn} disabled={isLoading} type="submit">
           Save
         </button>
       </form>

--- a/src/pages/TrackerPage/TrackerPage.jsx
+++ b/src/pages/TrackerPage/TrackerPage.jsx
@@ -14,13 +14,19 @@ import { getNumberMonth } from '../../utils/calendar.js';
 // import {parseDate} from '../../utils/calendar.js'
 
 const steps = [
-{selector: '.normaLitr', content: 'Your daily water intake'},
-{selector: '.scale', content: 'A scale that displays the ratio of the water you actually drink per day to your daily water intake requirement'},
-{selector: '.addWaterText', content: 'Click to add water!'},
-{selector: '.monthInfo', content: 'Detailed information about the water drunk for the selected day and month'},
-
+  { selector: '.normaLitr', content: 'Your daily water intake' },
+  {
+    selector: '.scale',
+    content:
+      'A scale that displays the ratio of the water you actually drink per day to your daily water intake requirement',
+  },
+  { selector: '.addWaterText', content: 'Click to add water!' },
+  {
+    selector: '.monthInfo',
+    content:
+      'Detailed information about the water drunk for the selected day and month',
+  },
 ];
-
 
 const TrackerPage = () => {
   const dispatch = useDispatch();
@@ -29,20 +35,20 @@ const TrackerPage = () => {
   const initialDate = new Date(serializedDate);
   const currentMonth = getNumberMonth(initialDate.getMonth() + 1);
   const currentYear = initialDate.getFullYear();
-  const date = { year: currentYear, month: currentMonth };
 
   useEffect(() => {
+    const date = { year: currentYear, month: currentMonth };
     dispatch(fetchMonthlyWaterEntries(date));
-  }, [dispatch, date]);
+  }, [dispatch, currentMonth, currentYear]);
 
   return (
     <TourProvider steps={steps}>
       <TourGuide />
-    <div className={css.wrapper}>
-      {/* <div>{isLoading && "Request in progress..."}</div> */}
-      <WaterMainInfo />
-      <WaterDetailedInfo />
-    </div>
+      <div className={css.wrapper}>
+        {/* <div>{isLoading && "Request in progress..."}</div> */}
+        <WaterMainInfo />
+        <WaterDetailedInfo />
+      </div>
     </TourProvider>
   );
 };

--- a/src/redux/date/selectors.js
+++ b/src/redux/date/selectors.js
@@ -1,5 +1,7 @@
-export const selectCurrentDate= (state) => state.date.currDate;
-export const selectActiveDay = (state) =>state.date.activeDay;
+export const selectCurrentDate = (state) => state.date.currDate;
+export const selectFormattedCurrentDate = (state) =>
+  state.date.formattedCurrDate;
+export const selectActiveDay = (state) => state.date.activeDay;
 const date = new Date(selectCurrentDate);
-  
+
 export const selectCurrentMonth = date.getMonth();

--- a/src/redux/date/slice.js
+++ b/src/redux/date/slice.js
@@ -1,11 +1,20 @@
 import { createSlice } from '@reduxjs/toolkit';
 
+const parseDate = (date) => {
+  const pad = (n) => String(n).padStart(2, '0');
+
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(
+    date.getDate()
+  )} ${pad(date.getHours())}:${pad(date.getMinutes())}`;
+};
+
 const currentDate = new Date();
 const slice = createSlice({
   name: 'date',
 
   initialState: {
     currDate: currentDate.toISOString(),
+    formattedCurrDate: parseDate(currentDate),
     activeDay: currentDate.getDate(),
   },
 
@@ -14,12 +23,14 @@ const slice = createSlice({
       return {
         ...state,
         currDate: action.payload,
+        formattedCurrDate: parseDate(new Date(action.payload)),
       };
     },
     changeActiveDay: (state, action) => {
       return {
         ...state,
         activeDay: action.payload,
+        formattedCurrDate: parseDate(new Date(action.payload)),
       };
     },
   },

--- a/src/redux/water/slice.js
+++ b/src/redux/water/slice.js
@@ -31,6 +31,7 @@ const waterSlice = createSlice({
         state.items.unshift(action.payload.data);
       })
       .addCase(fetchMonthlyWaterEntries.fulfilled, (state, { payload }) => {
+        state.isLoading = false;
         state.items = payload.data;
       })
       .addCase(patchWaterEntry.fulfilled, (state, { payload }) => {


### PR DESCRIPTION
- додано можливість "створення води" на інші дати календаря;
- додано лоадер до модалки, який відображається під час запиту на сервер;
- покращено роботу редюсера `fetchMonthlyWaterEntries` - він не змінював стан `isLoaded` на `false` в кінці запиту;
- внесено зміни в `TrackerPage` для уникнення постійного ререндеру (завершення `fetchMonthlyWaterEntries` змінювало значення двох змінних стану і це запускало повторні рендери).